### PR TITLE
Some tweaks for release

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 PaperMC
+Copyright (c) 2024 PaperMC
                    Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/README.md
+++ b/README.md
@@ -1,0 +1,38 @@
+# Paper Trail
+
+**Paper Trail** is a helper library for 
+notifying users of legacy server software 
+that a plugin requires Paper.
+The main use case for this library
+is for plugins that utilize the new
+Paper plugin system (`paper-plugin.yml`)
+and do not support the legacy plugin system
+(`plugin.yml`).
+
+Paper Trail offers a simple way to notify users
+that they need to upgrade to Paper by providing
+a stub `JavaPlugin` that prints a helpful message
+on startup then disables itself.
+An alternate message is used if the server is
+running Paper, but the version is too old to 
+support the Paper plugin system.
+
+### How to Use
+
+Add the PaperMC repository to your build script
+and shade `io.papermc:paper-trail:0.0.1-SNAPSHOT`
+into your plugin.
+It is recommended to relocate this dependency's
+package to avoid conflicts.
+
+To use Paper Trail, create a dummy
+`plugin.yml` in your plugin with 
+`io.papermc.papertrail.RequiresPaperPlugins`
+as the "main" class. 
+If you relocated the package, be sure to adjust 
+the class path in the yml accordingly.
+
+### License
+
+Paper Trail is licensed under the MIT License.
+See the LICENSE file for more information.

--- a/README.md
+++ b/README.md
@@ -12,27 +12,27 @@ and do not support the legacy plugin system
 Paper Trail offers a simple way to notify users
 that they need to upgrade to Paper by providing
 a stub `JavaPlugin` that prints a helpful message
-on startup then disables itself.
+on startup and then disables itself.
 An alternate message is used if the server is
 running Paper, but the version is too old to 
 support the Paper plugin system.
 
 ### How to Use
 
-Add the PaperMC repository to your build script
+Add the PaperMC repository (`https://repo.papermc.io/repository/maven-public/`) to your build script
 and shade `io.papermc:paper-trail:0.0.1-SNAPSHOT`
 into your plugin.
-It is recommended to relocate this dependency's
+It is recommended to relocate the `io.papermc.papertrail`
 package to avoid conflicts.
 
-To use Paper Trail, create a dummy
-`plugin.yml` in your plugin with 
+To use Paper Trail, add a
+`plugin.yml` to your plugin with 
 `io.papermc.papertrail.RequiresPaperPlugins`
 as the "main" class. 
 If you relocated the package, be sure to adjust 
-the class path in the yml accordingly.
+the class name in the yaml accordingly.
 
 ### License
 
 Paper Trail is licensed under the MIT License.
-See the LICENSE file for more information.
+See the [LICENSE](LICENSE) file for more information.

--- a/src/main/java/io/papermc/papertrail/RequiresPaperPlugins.java
+++ b/src/main/java/io/papermc/papertrail/RequiresPaperPlugins.java
@@ -21,7 +21,8 @@ public class RequiresPaperPlugins extends JavaPlugin {
         final List<String> lines = new ArrayList<>(Arrays.asList("", Util.EQUALS_LINE));
         lines.addAll(Util.PAPER ? this.outdatedPaper() : this.requiresPaper());
         lines.add(Util.EQUALS_LINE);
-        this.getLogger().log(Level.SEVERE, String.join("\n", lines), new UnsupportedPlatformException("Unsupported platform"));
+        this.getLogger().log(Level.SEVERE, String.join("\n", lines),
+            new UnsupportedPlatformException("Unsupported platform"));
     }
 
     private void disable() {
@@ -30,7 +31,12 @@ public class RequiresPaperPlugins extends JavaPlugin {
 
     private List<String> outdatedPaper() {
         final String pluginName = this.getDescription().getName();
-        return Arrays.asList(" " + pluginName + " requires Paper 1.19.4 or newer.");
+        return Arrays.asList(
+            " " + pluginName + " requires a newer version of Paper.",
+            " You can often find a list of supported game versions",
+            " at the webpage you obtained the plugin from. You could",
+            " also contact the plugin author for assistance."
+        );
     }
 
     private List<String> requiresPaper() {


### PR DESCRIPTION
There was some discussion in the discord recently about giving this a proper release, so I thought I'd make a few minor improvements in preparation for that.

This changes a few things to polish up the release.
- Bump copyright year since changes are being made to the code this year
- Add a proper readme with usage instructions
- Adjusted the "outdated paper" message. Instead of specifying paper version 1.19.4, we tell the user to check the plugin page for the right version to upgrade to, since the new plugin system has been around for a while and a lot of plugins probably won't support 1.19 in the near future. As it is written currently, a user might incorrectly assume that we're saying that the *plugin* requires/supports 1.19.4, when in reality that is simply the minimum version for the paper plugin system. (The new message intentionally does not mention the reason a newer paper is required, because it's probably not something the end user needs to know/care about.)